### PR TITLE
Small fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "fix": [
             "@fix:csfixer"
         ],
-        "test:unit": "vendor/bin/phpunit --testsuite=unit",
+        "test:unit": "vendor/bin/phpunit --testsuite=Unit",
         "test": [
             "@test:unit"
         ]

--- a/src/BackedEnum.php
+++ b/src/BackedEnum.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace PrinsFrank\Standards;
 
-class Enum
+class BackedEnum
 {
     /**
      * @template T of \BackedEnum

--- a/src/Country/ISO3166_1_Alpha_2.php
+++ b/src/Country/ISO3166_1_Alpha_2.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace PrinsFrank\Standards\Country;
 
-use PrinsFrank\Standards\Enum;
+use PrinsFrank\Standards\BackedEnum;
 
 /**
  * @source https://www.iso.org/obp/ui/#search/code/
@@ -262,11 +262,11 @@ enum ISO3166_1_Alpha_2: string
 
     public function toISO3166_1_Alpha_3(): ISO3166_1_Alpha_3
     {
-        return Enum::fromKey(ISO3166_1_Alpha_3::class, $this->name);
+        return BackedEnum::fromKey(ISO3166_1_Alpha_3::class, $this->name);
     }
 
     public function toISO3166_1_Numeric(): ISO3166_1_Numeric
     {
-        return Enum::fromKey(ISO3166_1_Numeric::class, $this->name);
+        return BackedEnum::fromKey(ISO3166_1_Numeric::class, $this->name);
     }
 }

--- a/src/Country/ISO3166_1_Alpha_3.php
+++ b/src/Country/ISO3166_1_Alpha_3.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace PrinsFrank\Standards\Country;
 
-use PrinsFrank\Standards\Enum;
+use PrinsFrank\Standards\BackedEnum;
 
 /**
  * @source https://www.iso.org/obp/ui/#search/code/
@@ -262,11 +262,11 @@ enum ISO3166_1_Alpha_3: string
 
     public function toISO3166_1_Alpha_2(): ISO3166_1_Alpha_2
     {
-        return Enum::fromKey(ISO3166_1_Alpha_2::class, $this->name);
+        return BackedEnum::fromKey(ISO3166_1_Alpha_2::class, $this->name);
     }
 
     public function toISO3166_1_Numeric(): ISO3166_1_Numeric
     {
-        return Enum::fromKey(ISO3166_1_Numeric::class, $this->name);
+        return BackedEnum::fromKey(ISO3166_1_Numeric::class, $this->name);
     }
 }

--- a/src/Country/ISO3166_1_Numeric.php
+++ b/src/Country/ISO3166_1_Numeric.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace PrinsFrank\Standards\Country;
 
-use PrinsFrank\Standards\Enum;
+use PrinsFrank\Standards\BackedEnum;
 
 /**
  * @source https://www.iso.org/obp/ui/#search/code/
@@ -272,11 +272,11 @@ enum ISO3166_1_Numeric: string
 
     public function toISO3166_1_Alpha_2(): ISO3166_1_Alpha_2
     {
-        return Enum::fromKey(ISO3166_1_Alpha_2::class, $this->name);
+        return BackedEnum::fromKey(ISO3166_1_Alpha_2::class, $this->name);
     }
 
     public function toISO3166_1_Alpha_3(): ISO3166_1_Alpha_3
     {
-        return Enum::fromKey(ISO3166_1_Alpha_3::class, $this->name);
+        return BackedEnum::fromKey(ISO3166_1_Alpha_3::class, $this->name);
     }
 }

--- a/src/Currency/ISO4217_Alpha3.php
+++ b/src/Currency/ISO4217_Alpha3.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace PrinsFrank\Standards\Currency;
 
-use PrinsFrank\Standards\Enum;
+use PrinsFrank\Standards\BackedEnum;
 
 enum ISO4217_Alpha3: string
 {
@@ -189,6 +189,6 @@ enum ISO4217_Alpha3: string
 
     public function toISO4217_Numeric(): ISO4217_Numeric
     {
-        return Enum::fromKey(ISO4217_Numeric::class, $this->name);
+        return BackedEnum::fromKey(ISO4217_Numeric::class, $this->name);
     }
 }

--- a/src/Currency/ISO4217_Numeric.php
+++ b/src/Currency/ISO4217_Numeric.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace PrinsFrank\Standards\Currency;
 
-use PrinsFrank\Standards\Enum;
+use PrinsFrank\Standards\BackedEnum;
 
 enum ISO4217_Numeric: string
 {
@@ -199,6 +199,6 @@ enum ISO4217_Numeric: string
 
     public function toISO4217_Alpha3(): ISO4217_Alpha3
     {
-        return Enum::fromKey(ISO4217_Alpha3::class, $this->name);
+        return BackedEnum::fromKey(ISO4217_Alpha3::class, $this->name);
     }
 }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -6,17 +6,19 @@ namespace PrinsFrank\Standards;
 class Enum
 {
     /**
-     * @template T of Enum
+     * @template T of \BackedEnum
      * @param class-string<T> $fqn
      * @return T|null
      */
-    public static function fromKey(string $fqn, string $keyName)
+    public static function fromKey(string $fqn, string $keyName): ?\BackedEnum
     {
-        $matchingItems = array_values(array_filter($fqn::cases(), static function ($language) use ($keyName) {return $language->name === $keyName;}));
-        if (array_key_exists(0, $matchingItems) === false || count($matchingItems) !== 1) {
-            return null;
+        foreach ($fqn::cases() as $case) {
+            if ($case->name === $keyName) {
+                // stop at first case found
+                return $case;
+            }
         }
 
-        return $matchingItems[0];
+        return null;
     }
 }

--- a/src/Language/ISO639_1_Alpha_2.php
+++ b/src/Language/ISO639_1_Alpha_2.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace PrinsFrank\Standards\Language;
 
-use PrinsFrank\Standards\Enum;
+use PrinsFrank\Standards\BackedEnum;
 
 /**
  * @source https://www.loc.gov/standards/iso639-2/php/code_list.php
@@ -196,11 +196,11 @@ enum ISO639_1_Alpha_2: string
 
     public function toISO639_2_Alpha_3_Bibliographic(): ISO639_2_Alpha_3_Common|ISO639_2_Alpha_3_Bibliographic|null
     {
-        return Enum::fromKey(ISO639_2_Alpha_3_Common::class, $this->name) ?? Enum::fromKey(ISO639_2_Alpha_3_Bibliographic::class, $this->name) ?? null;
+        return BackedEnum::fromKey(ISO639_2_Alpha_3_Common::class, $this->name) ?? BackedEnum::fromKey(ISO639_2_Alpha_3_Bibliographic::class, $this->name) ?? null;
     }
 
     public function toISO639_2_Alpha_3_Terminology(): ISO639_2_Alpha_3_Common|ISO639_2_Alpha_3_Terminology|null
     {
-        return Enum::fromKey(ISO639_2_Alpha_3_Common::class, $this->name) ?? Enum::fromKey(ISO639_2_Alpha_3_Terminology::class, $this->name) ?? null;
+        return BackedEnum::fromKey(ISO639_2_Alpha_3_Common::class, $this->name) ?? BackedEnum::fromKey(ISO639_2_Alpha_3_Terminology::class, $this->name) ?? null;
     }
 }

--- a/src/Language/ISO639_2_Alpha_3_Bibliographic.php
+++ b/src/Language/ISO639_2_Alpha_3_Bibliographic.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace PrinsFrank\Standards\Language;
 
-use PrinsFrank\Standards\Enum;
+use PrinsFrank\Standards\BackedEnum;
 
 /**
  * @source https://www.loc.gov/standards/iso639-2/php/code_list.php
@@ -33,11 +33,11 @@ enum ISO639_2_Alpha_3_Bibliographic: string
 
     public function toISO639_2_Alpha_3_Terminology(): ISO639_2_Alpha_3_Common|ISO639_2_Alpha_3_Terminology|null
     {
-        return Enum::fromKey(ISO639_2_Alpha_3_Common::class, $this->name) ?? Enum::fromKey(ISO639_2_Alpha_3_Terminology::class, $this->name) ?? null;
+        return BackedEnum::fromKey(ISO639_2_Alpha_3_Common::class, $this->name) ?? BackedEnum::fromKey(ISO639_2_Alpha_3_Terminology::class, $this->name) ?? null;
     }
 
     public function toISO639_1_Alpha_2(): ISO639_1_Alpha_2|null
     {
-        return Enum::fromKey(ISO639_1_Alpha_2::class, $this->name);
+        return BackedEnum::fromKey(ISO639_1_Alpha_2::class, $this->name);
     }
 }

--- a/src/Language/ISO639_2_Alpha_3_Common.php
+++ b/src/Language/ISO639_2_Alpha_3_Common.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace PrinsFrank\Standards\Language;
 
-use PrinsFrank\Standards\Enum;
+use PrinsFrank\Standards\BackedEnum;
 
 /**
  * @source https://www.loc.gov/standards/iso639-2/php/code_list.php
@@ -478,6 +478,6 @@ enum ISO639_2_Alpha_3_Common: string
 
     public function toISO639_1_Alpha_2(): ISO639_1_Alpha_2|null
     {
-        return Enum::fromKey(ISO639_1_Alpha_2::class, $this->name);
+        return BackedEnum::fromKey(ISO639_1_Alpha_2::class, $this->name);
     }
 }

--- a/src/Language/ISO639_2_Alpha_3_Terminology.php
+++ b/src/Language/ISO639_2_Alpha_3_Terminology.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace PrinsFrank\Standards\Language;
 
-use PrinsFrank\Standards\Enum;
+use PrinsFrank\Standards\BackedEnum;
 
 /**
  * @source https://www.loc.gov/standards/iso639-2/php/code_list.php
@@ -33,11 +33,11 @@ enum ISO639_2_Alpha_3_Terminology: string
 
     public function toISO639_2_Alpha_3_Bibliographic(): ISO639_2_Alpha_3_Common|ISO639_2_Alpha_3_Bibliographic|null
     {
-        return Enum::fromKey(ISO639_2_Alpha_3_Common::class, $this->name) ?? Enum::fromKey(ISO639_2_Alpha_3_Bibliographic::class, $this->name) ?? null;
+        return BackedEnum::fromKey(ISO639_2_Alpha_3_Common::class, $this->name) ?? BackedEnum::fromKey(ISO639_2_Alpha_3_Bibliographic::class, $this->name) ?? null;
     }
 
     public function toISO639_1_Alpha_2(): ISO639_1_Alpha_2|null
     {
-        return Enum::fromKey(ISO639_1_Alpha_2::class, $this->name);
+        return BackedEnum::fromKey(ISO639_1_Alpha_2::class, $this->name);
     }
 }

--- a/tests/Unit/Country/ISO3166_1_Alpha_2Test.php
+++ b/tests/Unit/Country/ISO3166_1_Alpha_2Test.php
@@ -19,7 +19,11 @@ class ISO3166_1_Alpha_2Test extends TestCase
         $cases = ISO3166_1_Alpha_2::cases();
         static::assertNotEmpty($cases);
         foreach ($cases as $case) {
-            static::assertNotNull($case->toISO3166_1_Alpha_3());
+            try {
+                $case->toISO3166_1_Alpha_3();
+            } catch (\TypeError) {
+                $this->fail(sprintf('Case %s could not be converted to ISO3166_1_Alpha_3', $case->name));
+            }
         }
     }
 
@@ -31,7 +35,11 @@ class ISO3166_1_Alpha_2Test extends TestCase
         $cases = ISO3166_1_Alpha_2::cases();
         static::assertNotEmpty($cases);
         foreach ($cases as $case) {
-            static::assertNotNull($case->toISO3166_1_Numeric());
+            try {
+                $case->toISO3166_1_Numeric();
+            } catch (\TypeError) {
+                $this->fail(sprintf('Case %s could not be converted to ISO3166_1_Numeric', $case->name));
+            }
         }
     }
 }

--- a/tests/Unit/Country/ISO3166_1_Alpha_3Test.php
+++ b/tests/Unit/Country/ISO3166_1_Alpha_3Test.php
@@ -19,7 +19,11 @@ class ISO3166_1_Alpha_3Test extends TestCase
         $cases = ISO3166_1_Alpha_3::cases();
         static::assertNotEmpty($cases);
         foreach ($cases as $case) {
-            static::assertNotNull($case->toISO3166_1_Alpha_2());
+            try {
+                $case->toISO3166_1_Alpha_2();
+            } catch (\TypeError) {
+                $this->fail(sprintf('Case %s could not be converted to ISO3166_1_Alpha_2', $case->name));
+            }
         }
     }
 
@@ -31,7 +35,11 @@ class ISO3166_1_Alpha_3Test extends TestCase
         $cases = ISO3166_1_Alpha_3::cases();
         static::assertNotEmpty($cases);
         foreach ($cases as $case) {
-            static::assertNotNull($case->toISO3166_1_Numeric());
+            try {
+                $case->toISO3166_1_Numeric();
+            } catch (\TypeError) {
+                $this->fail(sprintf('Case %s could not be converted to ISO3166_1_Numeric', $case->name));
+            }
         }
     }
 }

--- a/tests/Unit/Country/ISO3166_1_NumericTest.php
+++ b/tests/Unit/Country/ISO3166_1_NumericTest.php
@@ -20,7 +20,11 @@ class ISO3166_1_NumericTest extends TestCase
         $cases = ISO3166_1_Numeric::cases();
         static::assertNotEmpty($cases);
         foreach ($cases as $case) {
-            static::assertNotNull($case->toISO3166_1_Alpha_2());
+            try {
+                $case->toISO3166_1_Alpha_2();
+            } catch (\TypeError) {
+                $this->fail(sprintf('Case %s could not be converted to ISO3166_1_Alpha_2', $case->name));
+            }
         }
     }
 
@@ -32,7 +36,11 @@ class ISO3166_1_NumericTest extends TestCase
         $cases = ISO3166_1_Numeric::cases();
         static::assertNotEmpty($cases);
         foreach ($cases as $case) {
-            static::assertNotNull($case->toISO3166_1_Alpha_3());
+            try {
+                $case->toISO3166_1_Alpha_3();
+            } catch (\TypeError) {
+                $this->fail(sprintf('Case %s could not be converted to ISO3166_1_Alpha_3', $case->name));
+            }
         }
     }
 

--- a/tests/Unit/Currency/ISO4217_Alpha3Test.php
+++ b/tests/Unit/Currency/ISO4217_Alpha3Test.php
@@ -19,7 +19,11 @@ class ISO4217_Alpha3Test extends TestCase
         $cases = ISO4217_Alpha3::cases();
         static::assertNotEmpty($cases);
         foreach ($cases as $case) {
-            static::assertNotNull($case->toISO4217_Numeric());
+            try {
+                $case->toISO4217_Numeric();
+            } catch (\TypeError) {
+                $this->fail(sprintf('Case %s could not be converted to ISO4217_Numeric', $case->name));
+            }
         }
     }
 }

--- a/tests/Unit/Currency/ISO4217_NumericTest.php
+++ b/tests/Unit/Currency/ISO4217_NumericTest.php
@@ -20,7 +20,11 @@ class ISO4217_NumericTest extends TestCase
         $cases = ISO4217_Numeric::cases();
         static::assertNotEmpty($cases);
         foreach ($cases as $case) {
-            static::assertNotNull($case->toISO4217_Alpha3());
+            try {
+                $case->toISO4217_Alpha3();
+            } catch (\TypeError) {
+                $this->fail(sprintf('Case %s could not be converted to ISO4217_Alpha3', $case->name));
+            }
         }
     }
 


### PR DESCRIPTION
`Fix composer phpunit test suite`: no tests were running since the `unit` was lowercase

`Fix case convert tests when not expecting null`: since those converter functions were set to not return null (since they should be one for one), if it happened it would throw a `\TypeError`

`Simplify Enum:fromKey`: added return type to `?\BackedEnum` since they all are backed, also since the filter always expects one to be found, it can be simplified to return early on the first one found or null if none