### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/docs               export-ignore
+/tests              export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.php-cs-fixer      export-ignore
+/phpunit.xml.dist   export-ignore


### PR DESCRIPTION
With this file, we can ignore files/folder that are not used for package distribution. This will save disk space when user install the package.

![image](https://user-images.githubusercontent.com/20186786/174466535-278b8819-ef3a-4ee6-a862-4c4fc87894c0.png)

Before: `224KB`, After: `182K`. It saves around `42KB`. Its not a lot, but it saves some space.

Feel free to drop or accept this PR. Cheers :beers: 