### PR TITLE
Name Composer scripts like $tool:$action

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,21 +27,16 @@
         "dbrekelmans/bdi": "^1.0"
     },
     "scripts": {
-        "fix:csfixer": "vendor/bin/php-cs-fixer fix --allow-risky=yes",
-        "fix": [
-            "@fix:csfixer"
-        ],
-        "check:csfixer": "vendor/bin/php-cs-fixer fix --allow-risky=yes --dry-run",
-        "check": [
-            "@check:csfixer"
-        ],
-        "test:unit": "vendor/bin/phpunit --testsuite=Unit",
+        "cs": "php-cs-fixer fix --allow-risky=yes --dry-run",
+        "cs:fix": "php-cs-fixer fix --allow-risky=yes",
+        "unit": "phpunit --testsuite=Unit",
         "test": [
-            "@test:unit"
+            "@unit",
+            "@cs"
         ],
         "update-spec": [
             "PrinsFrank\\Standards\\Dev\\SpecUpdater::update",
-            "@fix:csfixer"
+            "@cs:fix"
         ]
     }
 }


### PR DESCRIPTION
❕ This is an inspirational PR.

All CLI tools think like this: Laravel's artisan, WP's wp-cli, actually all `symfony/console`-based tools.
