### PR TITLE
Add ::names ::values ::toArray helper to BackedEnum

### DIFF
--- a/src/BackedEnum.php
+++ b/src/BackedEnum.php
@@ -36,7 +36,7 @@ class BackedEnum
     /**
      * @template T of \BackedEnum
      * @param class-string<T> $fqn
-     * @return array
+     * @return array<positive-int, key-of<T>>
      */
     public static function names($fqn): array
     {
@@ -46,7 +46,7 @@ class BackedEnum
     /**
      * @template T of \BackedEnum
      * @param class-string<T> $fqn
-     * @return array
+     * @return array<positive-int, key-of<T>>
      */
     public static function values($fqn): array
     {
@@ -56,7 +56,7 @@ class BackedEnum
     /**
      * @template T of \BackedEnum
      * @param class-string<T> $fqn
-     * @return array
+     * @return array<positive-int, key-of<T>>
      */
     public static function toArray($fqn): array
     {

--- a/src/BackedEnum.php
+++ b/src/BackedEnum.php
@@ -20,9 +20,14 @@ class BackedEnum
      * @template T of \BackedEnum
      * @param class-string<T> $fqn
      * @return T|null
+     * @throws InvalidArgumentException
      */
     public static function tryFromKey(string $fqn, string $keyName): ?\BackedEnum
     {
+        if (is_a($fqn, \BackedEnum::class, true) === false) {
+            throw new InvalidArgumentException('It is only possible to get names of backedEnums, "' . $fqn . '" provided');
+        }
+
         if (!defined("$fqn::$keyName")) {
             return null;
         }
@@ -37,9 +42,14 @@ class BackedEnum
      * @template T of \BackedEnum
      * @param class-string<T> $fqn
      * @return array<int, string>
+     * @throws InvalidArgumentException
      */
-    public static function names($fqn): array
+    public static function names(string $fqn): array
     {
+        if (is_a($fqn, \BackedEnum::class, true) === false) {
+            throw new InvalidArgumentException('It is only possible to get names of backedEnums, "' . $fqn . '" provided');
+        }
+
         return array_column($fqn::cases(), 'name');
     }
 
@@ -47,9 +57,14 @@ class BackedEnum
      * @template T of \BackedEnum
      * @param class-string<T> $fqn
      * @return array<int, int|string>
+     * @throws InvalidArgumentException
      */
-    public static function values($fqn): array
+    public static function values(string $fqn): array
     {
+        if (is_a($fqn, \BackedEnum::class, true) === false) {
+            throw new InvalidArgumentException('It is only possible to get values of backedEnums, "' . $fqn . '" provided');
+        }
+
         return array_column($fqn::cases(), 'value');
     }
 
@@ -57,11 +72,15 @@ class BackedEnum
      * @template T of \BackedEnum
      * @param class-string<T> $fqn
      * @return array<int|string, int|string>
+     * @throws InvalidArgumentException
      */
-    public static function toArray($fqn): array
+    public static function toArray(string $fqn): array
     {
-        $array = [];
+        if (is_a($fqn, \BackedEnum::class, true) === false) {
+            throw new InvalidArgumentException('It is only possible to get an array of key/value pairs for backedEnums, "' . $fqn . '" provided');
+        }
 
+        $array = [];
         foreach ($fqn::cases() as $case) {
             $array[$case->name] = $case->value;
         }

--- a/src/BackedEnum.php
+++ b/src/BackedEnum.php
@@ -32,4 +32,40 @@ class BackedEnum
 
         return $itemValue;
     }
+
+    /**
+     * @template T of \BackedEnum
+     * @param class-string<T> $fqn
+     * @return array
+     */
+    public static function names($fqn): array
+    {
+        return array_column($fqn::cases(), 'name');
+    }
+
+    /**
+     * @template T of \BackedEnum
+     * @param class-string<T> $fqn
+     * @return array
+     */
+    public static function values($fqn): array
+    {
+        return array_column($fqn::cases(), 'value');
+    }
+
+    /**
+     * @template T of \BackedEnum
+     * @param class-string<T> $fqn
+     * @return array
+     */
+    public static function toArray($fqn): array
+    {
+        $array = [];
+
+        foreach ($fqn::cases() as $case) {
+            $array[$case->name] = $case->value;
+        }
+
+        return $array;
+    }
 }

--- a/src/BackedEnum.php
+++ b/src/BackedEnum.php
@@ -36,7 +36,7 @@ class BackedEnum
     /**
      * @template T of \BackedEnum
      * @param class-string<T> $fqn
-     * @return array<positive-int, key-of<T>>
+     * @return array<int, string>
      */
     public static function names($fqn): array
     {
@@ -46,7 +46,7 @@ class BackedEnum
     /**
      * @template T of \BackedEnum
      * @param class-string<T> $fqn
-     * @return array<positive-int, key-of<T>>
+     * @return array<int, int|string>
      */
     public static function values($fqn): array
     {
@@ -56,7 +56,7 @@ class BackedEnum
     /**
      * @template T of \BackedEnum
      * @param class-string<T> $fqn
-     * @return array<positive-int, key-of<T>>
+     * @return array<int|string, int|string>
      */
     public static function toArray($fqn): array
     {

--- a/src/InvalidArgumentException.php
+++ b/src/InvalidArgumentException.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace PrinsFrank\Standards;
+
+class InvalidArgumentException extends StandardException
+{
+}

--- a/tests/Unit/BackedEnumTest.php
+++ b/tests/Unit/BackedEnumTest.php
@@ -5,6 +5,7 @@ namespace PrinsFrank\Standards\Tests;
 
 use PHPUnit\Framework\TestCase;
 use PrinsFrank\Standards\BackedEnum;
+use PrinsFrank\Standards\InvalidArgumentException;
 use PrinsFrank\Standards\KeyNotFoundException;
 
 /**
@@ -22,6 +23,20 @@ class BackedEnumTest extends TestCase
 
         static::assertNull(BackedEnum::tryFromKey(TestEnumBackedByInt::class, 'BAR'));
         static::assertSame(TestEnumBackedByInt::FOO, BackedEnum::tryFromKey(TestEnumBackedByInt::class, 'FOO'));
+    }
+
+    /**
+     * @covers ::tryFromKey
+     */
+    public function testTryFromKeyThrowsExceptionOnNonEnumValue(): void
+    {
+        $testClass = new class {};
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('It is only possible to get names of backedEnums, "' . $testClass::class . '" provided');
+
+        /** @phpstan-ignore-next-line */
+        BackedEnum::tryFromKey($testClass::class, 'foo');
     }
 
     /**
@@ -49,6 +64,20 @@ class BackedEnumTest extends TestCase
     }
 
     /**
+     * @covers ::names
+     */
+    public function testNamesThrowsExceptionOnNonEnumValue(): void
+    {
+        $testClass = new class {};
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('It is only possible to get names of backedEnums, "' . $testClass::class . '" provided');
+
+        /** @phpstan-ignore-next-line */
+        BackedEnum::names($testClass::class);
+    }
+
+    /**
      * @covers ::values
      */
     public function testValues(): void
@@ -64,6 +93,20 @@ class BackedEnumTest extends TestCase
     }
 
     /**
+     * @covers ::values
+     */
+    public function testValuesThrowsExceptionOnNonEnumValue(): void
+    {
+        $testClass = new class {};
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('It is only possible to get values of backedEnums, "' . $testClass::class . '" provided');
+
+        /** @phpstan-ignore-next-line */
+        BackedEnum::values($testClass::class);
+    }
+
+    /**
      * @covers ::toArray
      */
     public function testToArray(): void
@@ -76,6 +119,20 @@ class BackedEnumTest extends TestCase
             BackedEnum::toArray(TestEnumBackedByInt::class),
             ['FOO' => 42, 'FIZ' => 43],
         );
+    }
+
+    /**
+     * @covers ::toArray
+     */
+    public function testToArrayThrowsExceptionOnNonEnumValue(): void
+    {
+        $testClass = new class {};
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('It is only possible to get an array of key/value pairs for backedEnums, "' . $testClass::class . '" provided');
+
+        /** @phpstan-ignore-next-line */
+        BackedEnum::toArray($testClass::class);
     }
 
     /**

--- a/tests/Unit/BackedEnumTest.php
+++ b/tests/Unit/BackedEnumTest.php
@@ -30,7 +30,7 @@ class BackedEnumTest extends TestCase
      */
     public function testTryFromKeyThrowsExceptionOnNonEnumValue(): void
     {
-        $testClass = new class {};
+        $testClass = new class () {};
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('It is only possible to get names of backedEnums, "' . $testClass::class . '" provided');
@@ -68,7 +68,7 @@ class BackedEnumTest extends TestCase
      */
     public function testNamesThrowsExceptionOnNonEnumValue(): void
     {
-        $testClass = new class {};
+        $testClass = new class () {};
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('It is only possible to get names of backedEnums, "' . $testClass::class . '" provided');
@@ -97,7 +97,7 @@ class BackedEnumTest extends TestCase
      */
     public function testValuesThrowsExceptionOnNonEnumValue(): void
     {
-        $testClass = new class {};
+        $testClass = new class () {};
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('It is only possible to get values of backedEnums, "' . $testClass::class . '" provided');
@@ -126,7 +126,7 @@ class BackedEnumTest extends TestCase
      */
     public function testToArrayThrowsExceptionOnNonEnumValue(): void
     {
-        $testClass = new class {};
+        $testClass = new class () {};
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('It is only possible to get an array of key/value pairs for backedEnums, "' . $testClass::class . '" provided');

--- a/tests/Unit/BackedEnumTest.php
+++ b/tests/Unit/BackedEnumTest.php
@@ -35,7 +35,7 @@ class BackedEnumTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('It is only possible to get names of backedEnums, "' . $testClass::class . '" provided');
 
-        /** @phpstan-ignore-next-line */
+        /** @phpstan-ignore-next-line as not everyone has PHPStan to tell them not to pass something else than an Enum FQN */
         BackedEnum::tryFromKey($testClass::class, 'foo');
     }
 
@@ -73,7 +73,7 @@ class BackedEnumTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('It is only possible to get names of backedEnums, "' . $testClass::class . '" provided');
 
-        /** @phpstan-ignore-next-line */
+        /** @phpstan-ignore-next-line as not everyone has PHPStan to tell them not to pass something else than an Enum FQN */
         BackedEnum::names($testClass::class);
     }
 
@@ -102,7 +102,7 @@ class BackedEnumTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('It is only possible to get values of backedEnums, "' . $testClass::class . '" provided');
 
-        /** @phpstan-ignore-next-line */
+        /** @phpstan-ignore-next-line as not everyone has PHPStan to tell them not to pass something else than an Enum FQN */
         BackedEnum::values($testClass::class);
     }
 
@@ -131,7 +131,7 @@ class BackedEnumTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('It is only possible to get an array of key/value pairs for backedEnums, "' . $testClass::class . '" provided');
 
-        /** @phpstan-ignore-next-line */
+        /** @phpstan-ignore-next-line as not everyone has PHPStan to tell them not to pass something else than an Enum FQN */
         BackedEnum::toArray($testClass::class);
     }
 

--- a/tests/Unit/BackedEnumTest.php
+++ b/tests/Unit/BackedEnumTest.php
@@ -34,6 +34,51 @@ class BackedEnumTest extends TestCase
     }
 
     /**
+     * @covers ::names
+     */
+    public function testNames(): void
+    {
+        static::assertSame(
+            BackedEnum::names(TestEnumBackedByString::class),
+            ['FOO', 'FIZ'],
+        );
+        static::assertSame(
+            BackedEnum::names(TestEnumBackedByInt::class),
+            ['FOO', 'FIZ'],
+        );
+    }
+
+    /**
+     * @covers ::values
+     */
+    public function testValues(): void
+    {
+        static::assertSame(
+            BackedEnum::values(TestEnumBackedByString::class),
+            ['foo', 'fiz'],
+        );
+        static::assertSame(
+            BackedEnum::values(TestEnumBackedByInt::class),
+            [42, 43],
+        );
+    }
+
+    /**
+     * @covers ::toArray
+     */
+    public function testToArray(): void
+    {
+        static::assertSame(
+            BackedEnum::toArray(TestEnumBackedByString::class),
+            ['FOO' => 'foo', 'FIZ' => 'fiz'],
+        );
+        static::assertSame(
+            BackedEnum::toArray(TestEnumBackedByInt::class),
+            ['FOO' => 42, 'FIZ' => 43],
+        );
+    }
+
+    /**
      * @covers ::fromKey
      */
     public function testFromKeyThrowsExceptionNonExistingKey(): void
@@ -47,9 +92,11 @@ class BackedEnumTest extends TestCase
 enum TestEnumBackedByString: string
 {
     case FOO = 'foo';
+    case FIZ = 'fiz';
 }
 
 enum TestEnumBackedByInt: int
 {
     case FOO = 42;
+    case FIZ = 43;
 }


### PR DESCRIPTION
This PR add static function `names()`, `values()` and `toArray` in the BackendEnum class.

```php
use PrinsFrank\Standards\BackedEnum;
use PrinsFrank\Standards\Language\ISO639_1_Alpha_2;

$array = BackedEnum::toArray(ISO639_1_Alpha_2::class);
$values = BackedEnum::values(ISO639_1_Alpha_2::class);
$names = BackedEnum::names(ISO639_1_Alpha_2::class);
```

This maybe useful and maybe not. Feel free to accept or drop this PR. Cheers :clinking_glasses: 

---

Apart from this, @PrinsFrank  what do you think instead of using it with BackedEnum class, 
use directly in the enum class it self. Like:

```php
use PrinsFrank\Standards\Language\ISO639_1_Alpha_2;

$array = ISO639_1_Alpha_2::toArray();
$values = ISO639_1_Alpha_2::values();
$names = ISO639_1_Alpha_2::names();

// and maybe add toJson too
$json = ISO639_1_Alpha_2::toJson();
```