### PR TITLE
Fix PHPStan usage

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Install dependencies
         run: composer install
       - name: Run PHPStan
-        run: php -d memory_limit=4G vendor/bin/phpstan analyse -vv
+        run: vendor/bin/phpstan analyse --memory-limit 4G


### PR DESCRIPTION
https://phpstan.org/user-guide/command-line-usage#--memory-limit

`-v` does not do much, `--debug` does.