### PR TITLE
Check key in NameNormalizer

### DIFF
--- a/dev/DataTarget/NameNormalizer.php
+++ b/dev/DataTarget/NameNormalizer.php
@@ -17,7 +17,7 @@ class NameNormalizer
 
         $key = str_replace([' ', ';', ',', '(', ')', '-', '.', '\'', '"', '/', '|', '=', '!', '?', '*', '[', ']', '~', '´'], '_', $key);
         if (preg_match('/[^0-9A-Z_a-z]/', $key) === 1) {
-            throw new TransliterationException();
+            throw new TransliterationException(sprintf('Invalid key: (%s)', $key));
         }
 
         return trim(str_replace(['__', '__'], ['_', '_'], $key), '_');

--- a/dev/DataTarget/NameNormalizer.php
+++ b/dev/DataTarget/NameNormalizer.php
@@ -15,7 +15,10 @@ class NameNormalizer
             throw new TransliterationException();
         }
 
-        $key = str_replace([' ', ';', ',', '(', ')', '-', '.', '\'', '"', '/', '|', '=', '!', '?', '*', '[', ']', '~', '´'], '_', $key);
+        // Supplemental IPA transliteration
+        $key = str_replace(['´', 'Ɔ'], ['', 'O'], $key);
+
+        $key = str_replace([' ', ';', ',', '(', ')', '-', '.', '\'', '"', '/', '|', '=', '!', '?', '*', '[', ']', '~'], '_', $key);
         if (preg_match('/[^0-9A-Z_a-z]/', $key) === 1) {
             throw new TransliterationException(sprintf('Invalid key: (%s)', $key));
         }

--- a/dev/DataTarget/NameNormalizer.php
+++ b/dev/DataTarget/NameNormalizer.php
@@ -16,6 +16,9 @@ class NameNormalizer
         }
 
         $key = str_replace([' ', ';', ',', '(', ')', '-', '.', '\'', '"', '/', '|', '=', '!', '?', '*', '[', ']', '~'], '_', $key);
+        if (preg_match('/[^0-9A-Z_a-z]/', $key) === 1) {
+            throw new TransliterationException();
+        }
 
         return trim(str_replace(['__', '__'], ['_', '_'], $key), '_');
     }


### PR DESCRIPTION
Allow only alphanumeric and underscore characters in Enum keys.

From #135 