### PR TITLE
Fix typo in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ env:
   PHPSTAN_CACHE_DIR: '.phpstan.result.cache'
   COVERAGE_PATH: 'coverage.xml'
   GH_TOKEN: ${{ github.token }}
-  MAIN_BRANCH: 'main'
 
 jobs:
   composer-build-dev:
@@ -200,12 +199,12 @@ jobs:
           key: phpstan-${{ github.ref_name }}
 
       - name: Clear previous version of PHPStan main cache
-        if: ${{ github.ref == format('refs/heads/{0}', env.MAIN_BRANCH) }}
+        if: ${{ github.ref_name == github.event.repository.default_branch }}
         continue-on-error: true
         run: gh actions-cache delete phpstan -B ${{ github.ref }} --confirm
 
       - name: Push PHPStan main cache
-        if: ${{ github.ref == format('refs/heads/{0}', env.MAIN_BRANCH) }}
+        if: ${{ github.ref_name == github.event.repository.default_branch }}
         uses: actions/cache/save@v3
         with:
           path: ${{ env.PHPSTAN_CACHE_DIR }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,12 +200,12 @@ jobs:
           key: phpstan-${{ github.ref_name }}
 
       - name: Clear previous version of PHPStan main cache
-        if: github.ref == 'refs/heads/$({ env.MAIN_BRANCH }}'
+        if: ${{ github.ref == format('refs/heads/{0}', env.MAIN_BRANCH) }}
         continue-on-error: true
         run: gh actions-cache delete phpstan -B ${{ github.ref }} --confirm
 
       - name: Push PHPStan main cache
-        if: github.ref == 'refs/heads/$({ env.MAIN_BRANCH }}'
+        if: ${{ github.ref == format('refs/heads/{0}', env.MAIN_BRANCH) }}
         uses: actions/cache/save@v3
         with:
           path: ${{ env.PHPSTAN_CACHE_DIR }}


### PR DESCRIPTION
Although there were only 2 typos: `$({` I've used a function to concatenate the two parts.
