### PR TITLE
Remove ignored non-ASCII from .typos.toml

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -10,8 +10,6 @@ extend-ignore-re = [
     "\\bself::[0-9A-Z_a-z]+ +=> .+,",
     "\\b(Country|Currency)[:0-9A-Z_a-z]+,",
     "\\b(Country|Currency)[:0-9A-Z_a-z]+ +=> [:0-9A-Z_a-z]+,",
-    # Non-ASCII
-    "gʌ²¹ba²¹",
 ]
 
 [default.extend-identifiers]


### PR DESCRIPTION
`gʌba` is transliterated now.
