### PR TITLE
Add digits to NameNormalizer::normalize

### DIFF
--- a/dev/DataTarget/NameNormalizer.php
+++ b/dev/DataTarget/NameNormalizer.php
@@ -42,9 +42,10 @@ class NameNormalizer
             ->replace('~', '_')
             ->keep(
                 (new Filter())
-                    ->addRange(new Character('a'), new Character('z'))
+                    ->addRange(new Character('0'), new Character('9'))
                     ->addRange(new Character('A'), new Character('Z'))
                     ->addChar(new Character('_'))
+                    ->addRange(new Character('a'), new Character('z'))
             )
             ->transliterate($key);
 


### PR DESCRIPTION
Digits were removed from keys, please see https://github.com/PrinsFrank/standards/actions/runs/7688426221/job/20949636914?pr=173

⚠️ Keys may not start with a digit. I do not know how to implement that.

From #173