### PR TITLE
Fix name of specs-regeneration workflow

### DIFF
--- a/.github/workflows/specs-regeneration.yml
+++ b/.github/workflows/specs-regeneration.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Specs
 
 on:
   push:


### PR DESCRIPTION
There were two "CI"-s.

![image](https://github.com/PrinsFrank/standards/assets/952007/9c3f0404-58cc-480c-81fa-f0ec171aba76)
