### PR TITLE
Fix PHP version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "php": "^8.1 || ^8.2 || ^8.3",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-intl": "*",
         "ext-mbstring": "*",
         "prinsfrank/enums": "^1.2"


### PR DESCRIPTION
for example `^8.2` means
- ">= 8.2"
- "< 9.0"

so all three meant "up to 9.0"

https://semver.madewithlove.com/?package=php&constraint=%5E8.2
vs.
https://semver.madewithlove.com/?package=php&constraint=~8.2.0
