### PR TITLE
Gracefully handle language renames by mapping previous name to new name instead of deprecating old key and adding a new one

### DIFF
--- a/dev/DataSource/Mapping/LanguageMapping.php
+++ b/dev/DataSource/Mapping/LanguageMapping.php
@@ -22,6 +22,11 @@ use Symfony\Component\Panther\DomCrawler\Crawler;
  */
 class LanguageMapping implements Mapping
 {
+    /** @var array<string, string> where key is the new name and value is the previous name */
+    private const RENAMES = [
+        'Tlicho; Dogrib' => 'Tlicho, Dogrib',
+    ];
+
     public static function url(): string
     {
         return 'https://www.loc.gov/standards/iso639-2/php/code_list.php';
@@ -79,7 +84,7 @@ class LanguageMapping implements Mapping
         $languageAlpha3Bibliographic = new EnumFile(LanguageAlpha3Bibliographic::class, KeySorting::class);
         $languageAlpha3Terminology = new EnumFile(LanguageAlpha3Terminology::class, KeySorting::class);
         foreach ($dataSet as $dataRow) {
-            $languageName->addCase(new EnumCase($dataRow->name, $dataRow->name));
+            $languageName->addCase(new EnumCase($dataRow->name, $dataRow->name, previousValue: array_key_exists($dataRow->name, self::RENAMES) ? self::RENAMES[$dataRow->name] : null));
 
             if (trim($dataRow->alpha2) !== '') {
                 $languageAlpha2->addCase(new EnumCase($dataRow->name, $dataRow->alpha2));

--- a/dev/DataTarget/EnumCase.php
+++ b/dev/DataTarget/EnumCase.php
@@ -18,7 +18,8 @@ class EnumCase
         public readonly string $name,
         public readonly string|int $value,
         public readonly array $attributes = [],
-        public readonly bool $deprecated = false
+        public readonly bool $deprecated = false,
+        public readonly string|null $previousValue = null,
     ) {
     }
 
@@ -45,7 +46,7 @@ class EnumCase
             $case .= PHP_EOL . $indenting . $attribute->__toString();
         }
 
-        $existingKeyWithValue = $enumFQN::tryFrom($this->value);
+        $existingKeyWithValue = $enumFQN::tryFrom($this->value) ?? $enumFQN::tryFrom($this->previousValue ?? '');
         $key = $existingKeyWithValue !== null ? $existingKeyWithValue->name : NameNormalizer::normalize($this->name);
         if ($existingKeyWithValue === null && is_string($this->value)) {
             $mostCommonScriptInString = ScriptAlias::mostCommonInString($this->value) ?? ScriptAlias::Code_for_undetermined_script;

--- a/dev/DataTarget/EnumFile.php
+++ b/dev/DataTarget/EnumFile.php
@@ -57,7 +57,18 @@ class EnumFile
     public function hasCaseWithValue(string|int $value): bool
     {
         foreach ($this->cases as $case) {
-            if ($case->value === $value) {
+            if ($case->value === $value || $case->previousValue === $value) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function hasCaseWithName(string $name): bool
+    {
+        foreach ($this->cases as $case) {
+            if ($case->name === $name) {
                 return true;
             }
         }

--- a/dev/SpecUpdater.php
+++ b/dev/SpecUpdater.php
@@ -29,7 +29,7 @@ class SpecUpdater
             $event->getIO()->writeRaw('Updating contents of enum "' . $enumFile->path . '"');
             if ($enumFile->hasCases() === true) {
                 foreach ($enumFile->enumFQN::cases() as $existingCase) {
-                    if ($enumFile->hasCaseWithValue($existingCase->value) === false) {
+                    if ($enumFile->hasCaseWithValue($existingCase->value) === false && $enumFile->hasCaseWithName($existingCase->name) === false) {
                         $enumFile->addCase(new EnumCase($existingCase->name, $existingCase->value, [], true));
                     }
                 }


### PR DESCRIPTION
Should fix issues in #252 