### PR TITLE
Properly sort enum cases based on their current name, instead of the name it would after current transliteration (Enum keys never change for BC)

### DIFF
--- a/dev/DataSource/Sorting/KeySorting.php
+++ b/dev/DataSource/Sorting/KeySorting.php
@@ -3,14 +3,20 @@ declare(strict_types=1);
 
 namespace PrinsFrank\Standards\Dev\DataSource\Sorting;
 
+use BackedEnum;
 use PrinsFrank\Standards\Dev\DataTarget\EnumCase;
-use PrinsFrank\Standards\Dev\DataTarget\NameNormalizer;
 use PrinsFrank\Standards\Dev\Exception\TransliterationException;
 use PrinsFrank\Transliteration\Exception\InvalidArgumentException;
 use PrinsFrank\Transliteration\Exception\RecursionException;
 use PrinsFrank\Transliteration\Exception\UnableToCreateTransliteratorException;
 
 class KeySorting implements Sorting {
+    /** @param class-string<BackedEnum> $enumFQN */
+    public function __construct(
+        private readonly string $enumFQN,
+    ) {
+    }
+
     /**
      * @throws InvalidArgumentException
      * @throws UnableToCreateTransliteratorException
@@ -18,6 +24,6 @@ class KeySorting implements Sorting {
      * @throws RecursionException
      */
     public function __invoke(EnumCase $a, EnumCase $b): int {
-        return ($a->deprecated ? 1 : 0) . NameNormalizer::normalize($a->name) <=> ($b->deprecated ? 1 : 0) . NameNormalizer::normalize($b->name);
+        return ($a->deprecated ? 1 : 0) . $a->getKey($this->enumFQN) <=> ($b->deprecated ? 1 : 0) . $b->getKey($this->enumFQN);
     }
 }

--- a/dev/DataTarget/SpecFile.php
+++ b/dev/DataTarget/SpecFile.php
@@ -9,7 +9,6 @@ use PrinsFrank\Standards\Dev\DataSource\Sorting\Sorting;
 use PrinsFrank\Standards\Dev\Exception\EnumNotFoundException;
 use PrinsFrank\Standards\Dev\Exception\TransliterationException;
 use PrinsFrank\Standards\InvalidArgumentException;
-use PrinsFrank\Standards\Scripts\ScriptAlias;
 use PrinsFrank\Transliteration\Exception\RecursionException;
 use PrinsFrank\Transliteration\Exception\UnableToCreateTransliteratorException;
 use RuntimeException;
@@ -111,11 +110,11 @@ class SpecFile {
         $newEnumContent = mb_substr($enumContent, 0, $startEnum + 1);
         $keyedCases = [];
         foreach ($this->cases as $case) {
-            $keyedCases[$case->name . (is_string($case->value) ? ScriptAlias::mostCommonInString($case->value)->value ?? '' : '') . $case->value] = $case;
+            $keyedCases[$case->getKey($this->FQN) . $case->value] = $case;
         }
 
         $deduplicatedCases = array_values($keyedCases);
-        usort($deduplicatedCases, new $this->sortingFQN());
+        usort($deduplicatedCases, new $this->sortingFQN($this->FQN));
         foreach ($deduplicatedCases as $key => $case) {
             $newEnumContent .= $case->toString($this->FQN, '    ', $key === 0);
         }

--- a/src/Language/LanguageAlpha3Bibliographic.php
+++ b/src/Language/LanguageAlpha3Bibliographic.php
@@ -133,6 +133,7 @@ enum LanguageAlpha3Bibliographic: string {
     case Dinka = 'din';
     case Divehi_Dhivehi_Maldivian = 'div';
     case Dogri = 'doi';
+    case Dogrib = 'dgr';
     case Dravidian_languages = 'dra';
     case Duala = 'dua';
     case Dutch_Flemish = 'dut';
@@ -454,7 +455,6 @@ enum LanguageAlpha3Bibliographic: string {
     case Tigrinya = 'tir';
     case Timne = 'tem';
     case Tiv = 'tiv';
-    case Dogrib = 'dgr';
     case Tlingit = 'tli';
     case Tok_Pisin = 'tpi';
     case Tokelau = 'tkl';

--- a/src/Language/LanguageAlpha3Terminology.php
+++ b/src/Language/LanguageAlpha3Terminology.php
@@ -134,6 +134,7 @@ enum LanguageAlpha3Terminology: string {
     case Dinka = 'din';
     case Divehi_Dhivehi_Maldivian = 'div';
     case Dogri = 'doi';
+    case Dogrib = 'dgr';
     case Dravidian_languages = 'dra';
     case Duala = 'dua';
     case Dutch_Flemish = 'nld';
@@ -455,7 +456,6 @@ enum LanguageAlpha3Terminology: string {
     case Tigrinya = 'tir';
     case Timne = 'tem';
     case Tiv = 'tiv';
-    case Dogrib = 'dgr';
     case Tlingit = 'tli';
     case Tok_Pisin = 'tpi';
     case Tokelau = 'tkl';

--- a/src/Language/LanguageName.php
+++ b/src/Language/LanguageName.php
@@ -126,6 +126,7 @@ enum LanguageName: string {
     case Dinka = 'Dinka';
     case Divehi_Dhivehi_Maldivian = 'Divehi; Dhivehi; Maldivian';
     case Dogri = 'Dogri';
+    case Dogrib = 'Tlicho; Dogrib';
     case Dravidian_languages = 'Dravidian languages';
     case Duala = 'Duala';
     case Dutch_Flemish = 'Dutch; Flemish';
@@ -447,7 +448,6 @@ enum LanguageName: string {
     case Tigrinya = 'Tigrinya';
     case Timne = 'Timne';
     case Tiv = 'Tiv';
-    case Dogrib = 'Tlicho; Dogrib';
     case Tlingit = 'Tlingit';
     case Tok_Pisin = 'Tok Pisin';
     case Tokelau = 'Tokelau';

--- a/src/TopLevelDomain/CountryCodeTLD.php
+++ b/src/TopLevelDomain/CountryCodeTLD.php
@@ -57,13 +57,13 @@ enum CountryCodeTLD: string implements TLD {
     case bg_cyrillic = 'бг';
     case bh = 'bh';
     case bharat_telugu = 'భారత్';
-    case bharata_kannada = 'ಭಾರತ';
-    case bharata_oriya = 'ଭାରତ';
     case bharata_bengali = 'ভাৰত';
     case bharata_bengali_2 = 'ভারত';
-    case bharata_gujarati = 'ભારત';
     case bharata_devanagari = 'भारत';
+    case bharata_gujarati = 'ભારત';
     case bharata_gurmukhi = 'ਭਾਰਤ';
+    case bharata_kannada = 'ಭಾರತ';
+    case bharata_oriya = 'ଭାରତ';
     case bharatam_devanagari = 'भारतम्';
     case bharatam_malayalam = 'ഭാരതം';
     case bharota_devanagari = 'भारोत';

--- a/src/TopLevelDomain/GenericTLD.php
+++ b/src/TopLevelDomain/GenericTLD.php
@@ -696,8 +696,8 @@ enum GenericTLD: string implements TLD {
     case ji_gou_han = '机构';
     case ji_tuan_han = '集团';
     case jia_dian_han = '家電';
-    case jia_li_han = '嘉里';
     case jia_li_da_jiu_dian_han = '嘉里大酒店';
+    case jia_li_han = '嘉里';
     case jian_kang_han = '健康';
     case jio = 'jio';
 


### PR DESCRIPTION
Fixes #281 #280 