### PR TITLE
Do not export editorconfig

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,8 +7,9 @@
 /docs/gifs          export-ignore
 /docs/images        export-ignore
 /tests              export-ignore
-/.gitattributes     export-ignore
 /CONTRIBUTING.md    export-ignore
+/.editorconfig      export-ignore
+/.gitattributes     export-ignore
 /.gitignore         export-ignore
 /.php-cs-fixer.php  export-ignore
 /phpstan.neon       export-ignore


### PR DESCRIPTION
Installed `prinsfrank/standards` the very first time 🎉

Noticed `.editorconfig` in the vendor directory.