### PR TITLE
Several languages have been renamed, and they can't be mapped to their old names without manually adding this mapping

### DIFF
--- a/dev/DataSource/Mapping/LanguageMapping.php
+++ b/dev/DataSource/Mapping/LanguageMapping.php
@@ -24,6 +24,12 @@ class LanguageMapping implements Mapping {
     /** @var array<string, string> where key is the new name and value is the previous name */
     private const RENAMES = [
         'Tlicho; Dogrib' => 'Tlicho, Dogrib',
+        'Dogri (macrolanguage)' => 'Dogri',
+        'Konkani (macrolanguage)' => 'Konkani',
+        'Malay (macrolanguage)' => 'Malay',
+        'Nepali (macrolanguage)' => 'Nepali',
+        'Oriya (macrolanguage)' => 'Oriya',
+        'Swahili (macrolanguage)' => 'Swahili',
     ];
 
     public static function url(): string {


### PR DESCRIPTION
See #296 where both the key and value are updated, and only their value should change as keys should be BC