### PR TITLE
Fix mapping from new Caribbean Guilder CurrencyNumeric to previous Netherlands Antillean Guilder as the numeric code stays the same

### DIFF
--- a/src/Currency/CurrencyAlpha3.php
+++ b/src/Currency/CurrencyAlpha3.php
@@ -217,6 +217,10 @@ enum CurrencyAlpha3: string {
     case Zimbabwe_Dollar = 'ZWL';
 
     public function toCurrencyNumeric(): CurrencyNumeric {
+        if ($this === self::Caribbean_Guilder) {
+            return CurrencyNumeric::Netherlands_Antillean_Guilder; // Cannot be renamed to be BC
+        }
+
         return BackedEnum::fromName(CurrencyNumeric::class, $this->name);
     }
 

--- a/src/Currency/CurrencyName.php
+++ b/src/Currency/CurrencyName.php
@@ -220,6 +220,10 @@ enum CurrencyName: string {
     }
 
     public function toCurrencyNumeric(): CurrencyNumeric {
+        if ($this === self::Caribbean_Guilder) {
+            return CurrencyNumeric::Netherlands_Antillean_Guilder; // Cannot be renamed to be BC
+        }
+
         return BackedEnum::fromName(CurrencyNumeric::class, $this->name);
     }
 


### PR DESCRIPTION
See https://www.six-group.com/en/products-services/financial-information/data-standards.html